### PR TITLE
[chore] 내 프로필과 운동 목록이 한번에 조회되도록 로직 수정(#LYC-77)

### DIFF
--- a/src/main/java/com/Lycle/Server/controller/FriendController.java
+++ b/src/main/java/com/Lycle/Server/controller/FriendController.java
@@ -13,7 +13,10 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -71,12 +74,17 @@ public class FriendController {
     public ResponseEntity<BasicResponse> searchFriend(Authentication authentication) {
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
         Long sharedId = userPrincipal.getSharedId();
+        Map<String,Object> result = new HashMap<>();
+
+        //Map 을 활용하여 profile 정보와 activity 조회 결과를 한 array 에 담아서 전송송
+       result.put("profile", userService.searchProfile(sharedId));
+        result.put("activities", activityService.searchActivity(sharedId));
+
         BasicResponse friendResponse = BasicResponse.builder()
                 .code(HttpStatus.OK.value())
                 .httpStatus(HttpStatus.OK)
                 .count(2)
-                .result(Collections.singletonList(userService.searchProfile(sharedId)))
-                .result(Collections.singletonList(activityService.searchActivity(sharedId)))
+                .result(Collections.singletonList(result))
                 .build();
 
         return new ResponseEntity<>(friendResponse, friendResponse.getHttpStatus());

--- a/src/main/java/com/Lycle/Server/controller/UserController.java
+++ b/src/main/java/com/Lycle/Server/controller/UserController.java
@@ -5,6 +5,7 @@ import com.Lycle.Server.dto.BasicResponse;
 import com.Lycle.Server.dto.User.UpdateInfoDto;
 import com.Lycle.Server.dto.User.UserJoinDto;
 import com.Lycle.Server.dto.User.UserLoginDto;
+import com.Lycle.Server.service.ActivityService;
 import com.Lycle.Server.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,11 +14,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final ActivityService activityService;
 
     @PostMapping("/join")
     public ResponseEntity<BasicResponse> joinUser(@RequestBody UserJoinDto userJoinDto) {
@@ -91,12 +95,15 @@ public class UserController {
     public ResponseEntity<BasicResponse> searchProfile(Authentication authentication) {
         BasicResponse profileResponse;
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        Map<String,Object> result = new HashMap<>();
+        result.put("profile", userService.searchProfile(userPrincipal.getId()));
+        result.put("activities", activityService.searchActivity(userPrincipal.getId()));
         profileResponse = BasicResponse.builder()
                 .code(HttpStatus.OK.value())
                 .httpStatus(HttpStatus.OK)
                 .message("회원 정보 조회가 완료되었습니다.")
                 .count(1)
-                .result(Collections.singletonList(userService.searchProfile(userPrincipal.getId())))
+                .result(Collections.singletonList(result))
                 .build();
         return new ResponseEntity<>(profileResponse, profileResponse.getHttpStatus());
     }

--- a/src/main/java/com/Lycle/Server/domain/Activity.java
+++ b/src/main/java/com/Lycle/Server/domain/Activity.java
@@ -25,11 +25,11 @@ public class Activity extends BaseTimeEntity {
 
     @Column(columnDefinition = "TINYINT(1)")
     @ColumnDefault("0")
-    private boolean finishChecked;
+    private Boolean finishChecked;
 
     @Column(columnDefinition = "TINYINT(1)")
     @ColumnDefault("0")
-    private boolean rewardChecked;
+    private Boolean rewardChecked;
 
     @Builder
     public Activity(Long id, Long userId, String category, String activityTime ,boolean finishChecked, boolean rewardChecked) {

--- a/src/main/java/com/Lycle/Server/dto/Activity/SearchActivityWrapper.java
+++ b/src/main/java/com/Lycle/Server/dto/Activity/SearchActivityWrapper.java
@@ -4,5 +4,6 @@ public interface SearchActivityWrapper {
     String getCreatedDate();
     String getCategory();
     String getActivityTime();
-    boolean isFinishChecked();
+    Boolean getFinishChecked();
+    Boolean getRewardChecked();
 }


### PR DESCRIPTION
기존에 프로필 조회 /운동 목록 조회 로 분리되어 있던 API 기능을 한번에 조회 가능하도록 로직을 변경하였습니다.